### PR TITLE
[FIX] bookstore_mgmt_google_books_api: Fix module dependency

### DIFF
--- a/bookstore_mgmt_google_books_api/__manifest__.py
+++ b/bookstore_mgmt_google_books_api/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "maintainers": ["peluko00", "miquelalzanillas"],
     "version": "17.0.1.0.0",
-    "depends": ["bookstore_mgmt", "web_notify"],
+    "depends": ["bookstore_mgmt", "web_notify", "stock"],
     "external_dependencies": {
         "python": ["google-books-api-wrapper", "Unidecode"],
     },


### PR DESCRIPTION
The problem is when you install de module stock and uploads that an error appears with this message:

`action_import_from_isbn no es una acción válida en product.product
View error context:
{'file': '/opt/odoo/addons/stock/views/product_views.xml',
 'line': 2,
 'name': 'product.product.procurement',
 'view': ir.ui.view(1186,),
 'view.model': 'product.product',
 'view.parent': ir.ui.view(492,),
 'xmlid': 'product_form_view_procurement_button'}`
I solved that adding a stock module of dependency of the module because this view is from that module and inherit an product view.

cc https://github.com/APSL 163353
@miquelalzanillas @lbarry-apsl @javierobcn @mpascuall @BernatObrador @ppyczko please review